### PR TITLE
Add API key authentication provider

### DIFF
--- a/cmd/authguard/main.go
+++ b/cmd/authguard/main.go
@@ -14,6 +14,7 @@ import (
 	"authguard/internal/handlers"
 	"authguard/internal/logging"
 	"authguard/internal/metrics"
+	"authguard/internal/providers/apikey"
 	"authguard/internal/providers/firebase"
 	ipwhitelist "authguard/internal/providers/ip_whitelist"
 )
@@ -163,6 +164,11 @@ func registerProviders(authGuard *auth.AuthGuard, config *auth.Config, cache aut
 			provider := ipwhitelist.NewProvider(cache, lockManager, logger, metrics)
 			if err := authGuard.RegisterProvider(provider); err != nil {
 				return fmt.Errorf("failed to register ip_whitelist provider: %w", err)
+			}
+		case auth.ProviderTypeAPIKey:
+			provider := apikey.NewProvider(cache, lockManager, logger, metrics)
+			if err := authGuard.RegisterProvider(provider); err != nil {
+				return fmt.Errorf("failed to register api_key provider: %w", err)
 			}
 		default:
 			logger.Warn("unknown provider type", "provider", providerType)

--- a/config.example.yml
+++ b/config.example.yml
@@ -25,6 +25,7 @@ cache:
 providers:
   - firebase
   - ip_whitelist
+  - api_key
 
 # Logging Configuration
 logging:
@@ -47,6 +48,10 @@ metrics:
 # AUTHGUARD_IP_WHITELIST_ALLOWED_IPS="127.0.0.1,::1,192.168.1.0/24"
 # AUTHGUARD_IP_WHITELIST_PROXY_HEADER="X-Real-IP"
 # AUTHGUARD_IP_WHITELIST_TRUSTED_PROXIES="10.0.0.0/8,172.16.0.0/12"
+#
+# API Key Provider:
+# AUTHGUARD_API_KEY_KEYS="key1:user1:email1@example.com:User One,key2:user2:email2@example.com:User Two"
+# AUTHGUARD_API_KEY_HEADER_NAME="X-API-Key"
 #
 # Cache Configuration (override YAML):
 # AUTHGUARD_CACHE_TYPE="redis"

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -18,6 +18,7 @@ const (
 	ProviderTypeUnknown ProviderType = iota
 	ProviderTypeFirebase
 	ProviderTypeIPWhitelist
+	ProviderTypeAPIKey
 )
 
 // String returns the string representation of the provider type
@@ -27,6 +28,8 @@ func (p ProviderType) String() string {
 		return "firebase"
 	case ProviderTypeIPWhitelist:
 		return "ip_whitelist"
+	case ProviderTypeAPIKey:
+		return "api_key"
 	default:
 		return "unknown"
 	}
@@ -39,6 +42,8 @@ func ParseProviderType(s string) ProviderType {
 		return ProviderTypeFirebase
 	case "ip_whitelist":
 		return ProviderTypeIPWhitelist
+	case "api_key":
+		return ProviderTypeAPIKey
 	default:
 		return ProviderTypeUnknown
 	}
@@ -89,7 +94,7 @@ func (ac *AuthContext) ReadBody() ([]byte, error) {
 type LockManager interface {
 	// Lock acquires a lock for the given key
 	Lock(key string)
-	
+
 	// Unlock releases the lock for the given key
 	Unlock(key string)
 }

--- a/internal/cache/redis.go
+++ b/internal/cache/redis.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"authguard/internal/auth"
+
 	"github.com/redis/go-redis/v9"
 )
 

--- a/internal/providers/apikey/config.go
+++ b/internal/providers/apikey/config.go
@@ -1,0 +1,110 @@
+package apikey
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Config holds the API key provider configuration
+type Config struct {
+	// APIKeys is a map of API key to user info
+	// Format: "key1=user1,key2=user2" or JSON string
+	APIKeys map[string]APIKeyInfo `json:"api_keys"`
+
+	// HeaderName is the header name to look for the API key (default: "X-API-Key")
+	HeaderName string `json:"header_name"`
+}
+
+// APIKeyInfo contains information about an API key user
+type APIKeyInfo struct {
+	UserID       string         `json:"user_id"`
+	Email        string         `json:"email,omitempty"`
+	Name         string         `json:"name,omitempty"`
+	IsAdmin      bool           `json:"is_admin,omitempty"`
+	CustomClaims map[string]any `json:"custom_claims,omitempty"`
+}
+
+// Validate validates the API key configuration
+func (c *Config) Validate() error {
+	if len(c.APIKeys) == 0 {
+		return fmt.Errorf("at least one API key must be configured")
+	}
+
+	// Validate header name
+	if c.HeaderName == "" {
+		c.HeaderName = "X-API-Key" // Default header name
+	}
+
+	// Validate API key entries
+	for key, info := range c.APIKeys {
+		if key == "" {
+			return fmt.Errorf("API key cannot be empty")
+		}
+
+		if info.UserID == "" {
+			return fmt.Errorf("user_id is required for API key: %s", key)
+		}
+
+		// Validate key format (should be at least 16 characters for security)
+		if len(key) < 16 {
+			return fmt.Errorf("API key must be at least 16 characters long: %s", key)
+		}
+	}
+
+	return nil
+}
+
+// HasAPIKey checks if the given API key exists
+func (c *Config) HasAPIKey(apiKey string) bool {
+	_, exists := c.APIKeys[apiKey]
+	return exists
+}
+
+// GetAPIKeyInfo returns the API key info for the given key
+func (c *Config) GetAPIKeyInfo(apiKey string) (APIKeyInfo, bool) {
+	info, exists := c.APIKeys[apiKey]
+	return info, exists
+}
+
+// ParseAPIKeysFromString parses API keys from a string format
+// Format: "key1:user1:email1:name1,key2:user2:email2:name2"
+func ParseAPIKeysFromString(keysStr string) (map[string]APIKeyInfo, error) {
+	if keysStr == "" {
+		return make(map[string]APIKeyInfo), nil
+	}
+
+	keys := make(map[string]APIKeyInfo)
+	entries := strings.SplitSeq(keysStr, ",")
+
+	for entry := range entries {
+		parts := strings.Split(strings.TrimSpace(entry), ":")
+		if len(parts) < 2 {
+			return nil, fmt.Errorf("invalid API key entry format: %s (expected key:user_id[:email[:name]])", entry)
+		}
+
+		apiKey := strings.TrimSpace(parts[0])
+		userID := strings.TrimSpace(parts[1])
+
+		if apiKey == "" || userID == "" {
+			return nil, fmt.Errorf("API key and user_id cannot be empty in entry: %s", entry)
+		}
+
+		info := APIKeyInfo{
+			UserID: userID,
+		}
+
+		// Optional email
+		if len(parts) > 2 && strings.TrimSpace(parts[2]) != "" {
+			info.Email = strings.TrimSpace(parts[2])
+		}
+
+		// Optional name
+		if len(parts) > 3 && strings.TrimSpace(parts[3]) != "" {
+			info.Name = strings.TrimSpace(parts[3])
+		}
+
+		keys[apiKey] = info
+	}
+
+	return keys, nil
+}

--- a/internal/providers/apikey/config_test.go
+++ b/internal/providers/apikey/config_test.go
@@ -1,0 +1,171 @@
+package apikey
+
+import (
+	"testing"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      *Config
+		expectError bool
+	}{
+		{
+			name: "valid config",
+			config: &Config{
+				APIKeys: map[string]APIKeyInfo{
+					"test_key_1234567890": {UserID: "user1"},
+				},
+				HeaderName: "X-API-Key",
+			},
+			expectError: false,
+		},
+		{
+			name: "empty API keys",
+			config: &Config{
+				APIKeys:    map[string]APIKeyInfo{},
+				HeaderName: "X-API-Key",
+			},
+			expectError: true,
+		},
+		{
+			name: "short API key",
+			config: &Config{
+				APIKeys: map[string]APIKeyInfo{
+					"short": {UserID: "user1"},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty user ID",
+			config: &Config{
+				APIKeys: map[string]APIKeyInfo{
+					"test_key_1234567890": {UserID: ""},
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "default header name",
+			config: &Config{
+				APIKeys: map[string]APIKeyInfo{
+					"test_key_1234567890": {UserID: "user1"},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+
+			if tt.expectError && err == nil {
+				t.Error("Expected validation error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected validation error: %v", err)
+			}
+
+			// Check defaults are set
+			if !tt.expectError {
+				if tt.config.HeaderName == "" {
+					t.Error("HeaderName should have been set to default")
+				}
+			}
+		})
+	}
+}
+
+func TestConfig_HasAPIKey(t *testing.T) {
+	config := &Config{
+		APIKeys: map[string]APIKeyInfo{
+			"existing_key_123456": {UserID: "user1"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		key      string
+		expected bool
+	}{
+		{
+			name:     "existing key",
+			key:      "existing_key_123456",
+			expected: true,
+		},
+		{
+			name:     "non-existing key",
+			key:      "non_existing_key",
+			expected: false,
+		},
+		{
+			name:     "empty key",
+			key:      "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := config.HasAPIKey(tt.key)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestConfig_GetAPIKeyInfo(t *testing.T) {
+	testInfo := APIKeyInfo{
+		UserID: "user1",
+		Email:  "test@example.com",
+		Name:   "Test User",
+	}
+
+	config := &Config{
+		APIKeys: map[string]APIKeyInfo{
+			"existing_key_123456": testInfo,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		key        string
+		expectOK   bool
+		expectInfo APIKeyInfo
+	}{
+		{
+			name:       "existing key",
+			key:        "existing_key_123456",
+			expectOK:   true,
+			expectInfo: testInfo,
+		},
+		{
+			name:     "non-existing key",
+			key:      "non_existing_key",
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, ok := config.GetAPIKeyInfo(tt.key)
+			if ok != tt.expectOK {
+				t.Errorf("Expected ok=%v, got ok=%v", tt.expectOK, ok)
+			}
+			if tt.expectOK {
+				if info.UserID != tt.expectInfo.UserID {
+					t.Errorf("Expected UserID %s, got %s", tt.expectInfo.UserID, info.UserID)
+				}
+				if info.Email != tt.expectInfo.Email {
+					t.Errorf("Expected Email %s, got %s", tt.expectInfo.Email, info.Email)
+				}
+				if info.Name != tt.expectInfo.Name {
+					t.Errorf("Expected Name %s, got %s", tt.expectInfo.Name, info.Name)
+				}
+			}
+		})
+	}
+}

--- a/internal/providers/apikey/errors.go
+++ b/internal/providers/apikey/errors.go
@@ -1,0 +1,14 @@
+package apikey
+
+import "errors"
+
+var (
+	// ErrMissingAPIKey indicates that no API key was provided
+	ErrMissingAPIKey = errors.New("missing API key")
+
+	// ErrInvalidAPIKey indicates that the provided API key is invalid
+	ErrInvalidAPIKey = errors.New("invalid API key")
+
+	// ErrAPIKeyNotFound indicates that the API key was not found in configuration
+	ErrAPIKeyNotFound = errors.New("API key not found")
+)

--- a/internal/providers/apikey/provider.go
+++ b/internal/providers/apikey/provider.go
@@ -1,0 +1,257 @@
+package apikey
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"strings"
+	"time"
+
+	"authguard/internal/auth"
+)
+
+// Provider implements the AuthProvider interface for API key authentication
+type Provider struct {
+	config      *Config
+	logger      auth.Logger
+	metrics     auth.Metrics
+	cache       auth.Cache
+	lockManager auth.LockManager
+}
+
+// NewProvider creates a new API key authentication provider
+func NewProvider(cache auth.Cache, lockManager auth.LockManager, logger auth.Logger, metrics auth.Metrics) *Provider {
+	return &Provider{
+		logger:      logger.With("provider", "api_key"),
+		metrics:     metrics,
+		cache:       cache,
+		lockManager: lockManager,
+	}
+}
+
+// Type returns the provider type
+func (p *Provider) Type() auth.ProviderType {
+	return auth.ProviderTypeAPIKey
+}
+
+// LoadConfig loads and validates API key configuration
+func (p *Provider) LoadConfig(loader auth.ConfigLoader) error {
+	config := &Config{
+		APIKeys: make(map[string]APIKeyInfo),
+	}
+
+	// Load header name (default: "X-API-Key")
+	config.HeaderName = loader.GetWithDefault("api_key.header_name", "X-API-Key")
+
+	// Load API keys from string format
+	keysStr := loader.GetWithDefault("api_key.keys", "")
+	if keysStr != "" {
+		keys, err := ParseAPIKeysFromString(keysStr)
+		if err != nil {
+			return fmt.Errorf("failed to parse API keys: %w", err)
+		}
+		config.APIKeys = keys
+	}
+
+	// Load API keys from JSON format (alternative)
+	keysJSON := loader.GetWithDefault("api_key.keys_json", "")
+	if keysJSON != "" {
+		var keys map[string]APIKeyInfo
+		if err := json.Unmarshal([]byte(keysJSON), &keys); err != nil {
+			return fmt.Errorf("failed to parse API keys JSON: %w", err)
+		}
+		// Merge with existing keys
+		maps.Copy(config.APIKeys, keys)
+	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return fmt.Errorf("api_key config validation failed: %w", err)
+	}
+
+	p.config = config
+	p.logger.Info("api_key provider configured",
+		"keys_count", len(config.APIKeys),
+		"header_name", config.HeaderName)
+
+	return nil
+}
+
+// Validate validates API key authentication from AuthContext and returns user claims
+func (p *Provider) Validate(ctx context.Context, authCtx *auth.AuthContext) (*auth.UserClaims, error) {
+	start := time.Now()
+	defer func() {
+		p.metrics.ObserveValidationDuration("api_key", time.Since(start))
+	}()
+
+	p.metrics.IncProviderRequests("api_key")
+
+	// Extract API key from headers or query parameters
+	apiKey, source, err := p.extractAPIKey(authCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate cache key
+	cacheKey := p.generateCacheKey(apiKey)
+
+	// Use lock to prevent concurrent validation of the same key
+	p.lockManager.Lock(cacheKey)
+	defer p.lockManager.Unlock(cacheKey)
+
+	// Check cache first
+	if cachedClaims := p.getCachedClaims(ctx, cacheKey); cachedClaims != nil {
+		p.logger.Debug("cache hit for API key validation", "source", source, "subject", cachedClaims.Subject)
+		return cachedClaims, nil
+	}
+
+	// Validate API key against configuration
+	keyInfo, exists := p.config.GetAPIKeyInfo(apiKey)
+	if !exists {
+		p.logger.Debug("API key not found", "source", source)
+		return nil, auth.ErrUnauthorized
+	}
+
+	// Convert to UserClaims
+	userClaims := p.convertToUserClaims(keyInfo, source)
+
+	// Cache the successful result (API keys don't expire by default)
+	p.setCachedClaims(ctx, cacheKey, userClaims)
+
+	p.logger.Debug("API key validated successfully and cached",
+		"source", source,
+		"subject", userClaims.Subject)
+
+	return userClaims, nil
+}
+
+// extractAPIKey extracts the API key from headers
+func (p *Provider) extractAPIKey(authCtx *auth.AuthContext) (string, string, error) {
+	// Try header first
+	if apiKey, ok := authCtx.GetHeader(p.config.HeaderName); ok && apiKey != "" {
+		return strings.TrimSpace(apiKey), "header", nil
+	}
+
+	// Try Authorization header with "Bearer" prefix as fallback
+	if authHeader, ok := authCtx.GetHeader("Authorization"); ok {
+		const bearerPrefix = "Bearer "
+		if len(authHeader) > len(bearerPrefix) && strings.HasPrefix(authHeader, bearerPrefix) {
+			apiKey := strings.TrimSpace(authHeader[len(bearerPrefix):])
+			if apiKey != "" {
+				return apiKey, "authorization_header", nil
+			}
+		}
+	}
+
+	return "", "", auth.ErrUnauthorized
+}
+
+// generateCacheKey creates a cache key for API keys using format "api_key:key_hash"
+func (p *Provider) generateCacheKey(apiKey string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(apiKey))
+	return "api_key:" + hex.EncodeToString(hasher.Sum(nil))[:16] // Use first 16 chars for shorter keys
+}
+
+// getCachedClaims retrieves cached claims if available
+func (p *Provider) getCachedClaims(ctx context.Context, cacheKey string) *auth.UserClaims {
+	data, err := p.cache.Get(ctx, cacheKey)
+	if err != nil {
+		if !errors.Is(err, auth.ErrCacheKeyNotFound) {
+			p.logger.Debug("cache get error", "key", cacheKey, "error", err)
+		}
+		return nil
+	}
+
+	var claims auth.UserClaims
+	if err := json.Unmarshal(data, &claims); err != nil {
+		p.logger.Debug("cache unmarshal error", "key", cacheKey, "error", err)
+		return nil
+	}
+
+	return &claims
+}
+
+// setCachedClaims stores authentication claims in cache
+func (p *Provider) setCachedClaims(ctx context.Context, cacheKey string, claims *auth.UserClaims) {
+	data, err := json.Marshal(claims)
+	if err != nil {
+		p.logger.Debug("cache marshal error", "key", cacheKey, "error", err)
+		return
+	}
+
+	// API keys don't expire, so use a long TTL (24 hours)
+	ttl := 24 * time.Hour
+
+	if err := p.cache.Set(ctx, cacheKey, data, ttl); err != nil {
+		p.logger.Debug("cache set error", "key", cacheKey, "error", err)
+	} else {
+		p.logger.Debug("cached API key validation result", "key", cacheKey, "ttl", ttl)
+	}
+}
+
+// convertToUserClaims converts API key info to UserClaims
+func (p *Provider) convertToUserClaims(keyInfo APIKeyInfo, source string) *auth.UserClaims {
+	now := time.Now()
+
+	claims := &auth.UserClaims{
+		Subject:      keyInfo.UserID,
+		Email:        keyInfo.Email,
+		Name:         keyInfo.Name,
+		Provider:     auth.ProviderTypeAPIKey,
+		IssuedAt:     now,
+		ExpiresAt:    time.Time{}, // API keys don't expire by default
+		Issuer:       "authguard-api-key",
+		CustomClaims: make(map[string]any),
+	}
+
+	// Add custom claims from config
+	if keyInfo.CustomClaims != nil {
+		maps.Copy(claims.CustomClaims, keyInfo.CustomClaims)
+	}
+
+	// Add API key specific claims
+	claims.CustomClaims["api_key_source"] = source
+	if keyInfo.IsAdmin {
+		claims.CustomClaims["is_admin"] = true
+	}
+
+	return claims
+}
+
+// Health checks the API key provider's health
+func (p *Provider) Health(ctx context.Context) error {
+	if p.config == nil {
+		return fmt.Errorf("api_key provider not configured")
+	}
+
+	if len(p.config.APIKeys) == 0 {
+		return fmt.Errorf("no API keys configured")
+	}
+
+	return nil
+}
+
+// Close closes the provider and cleans up resources
+func (p *Provider) Close() error {
+	// No resources to clean up
+	return nil
+}
+
+// Stats returns API key provider statistics
+func (p *Provider) Stats() any {
+	if p.config == nil {
+		return map[string]any{
+			"status": "not_configured",
+		}
+	}
+
+	return map[string]any{
+		"keys_count":  len(p.config.APIKeys),
+		"header_name": p.config.HeaderName,
+	}
+}

--- a/internal/providers/apikey/provider_test.go
+++ b/internal/providers/apikey/provider_test.go
@@ -1,0 +1,445 @@
+package apikey
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"authguard/internal/auth"
+)
+
+// mockCache implements auth.Cache for testing
+type mockCache struct {
+	data map[string][]byte
+}
+
+func newMockCache() *mockCache {
+	return &mockCache{
+		data: make(map[string][]byte),
+	}
+}
+
+func (m *mockCache) Get(ctx context.Context, key string) ([]byte, error) {
+	if data, exists := m.data[key]; exists {
+		return data, nil
+	}
+	return nil, auth.ErrCacheKeyNotFound
+}
+
+func (m *mockCache) Set(ctx context.Context, key string, value []byte, ttl time.Duration) error {
+	m.data[key] = value
+	return nil
+}
+
+func (m *mockCache) Delete(ctx context.Context, key string) error {
+	delete(m.data, key)
+	return nil
+}
+
+func (m *mockCache) Clear(ctx context.Context) error {
+	m.data = make(map[string][]byte)
+	return nil
+}
+
+func (m *mockCache) Exists(ctx context.Context, key string) bool {
+	_, exists := m.data[key]
+	return exists
+}
+
+func (m *mockCache) Stats() auth.CacheStats {
+	return auth.CacheStats{
+		Keys: int64(len(m.data)),
+	}
+}
+
+func (m *mockCache) Close() error {
+	return nil
+}
+
+// mockLockManager implements auth.LockManager for testing
+type mockLockManager struct{}
+
+func (m *mockLockManager) Lock(key string)   {}
+func (m *mockLockManager) Unlock(key string) {}
+
+// mockLogger implements auth.Logger for testing
+type mockLogger struct{}
+
+func (m *mockLogger) Debug(msg string, keysAndValues ...interface{}) {}
+func (m *mockLogger) Info(msg string, keysAndValues ...interface{})  {}
+func (m *mockLogger) Warn(msg string, keysAndValues ...interface{})  {}
+func (m *mockLogger) Error(msg string, keysAndValues ...interface{}) {}
+func (m *mockLogger) With(keysAndValues ...interface{}) auth.Logger  { return m }
+
+// mockMetrics implements auth.Metrics for testing
+type mockMetrics struct{}
+
+func (m *mockMetrics) IncValidationAttempts(result string)                                    {}
+func (m *mockMetrics) ObserveValidationDuration(provider string, duration time.Duration)      {}
+func (m *mockMetrics) IncProviderRequests(provider string)                                    {}
+func (m *mockMetrics) IncCacheHits(provider string)                                           {}
+func (m *mockMetrics) IncCacheMisses(provider string)                                         {}
+func (m *mockMetrics) IncProviderErrors(provider string, errorType string)                    {}
+func (m *mockMetrics) ObserveCacheOperationDuration(operation string, duration time.Duration) {}
+func (m *mockMetrics) SetActiveConnections(count int)                                         {}
+func (m *mockMetrics) SetCachedKeys(provider string, count int)                               {}
+func (m *mockMetrics) SetProviderStatus(provider string, healthy bool)                        {}
+
+// mockConfigLoader implements auth.ConfigLoader for testing
+type mockConfigLoader struct {
+	data map[string]string
+}
+
+func newMockConfigLoader(data map[string]string) *mockConfigLoader {
+	return &mockConfigLoader{data: data}
+}
+
+func (m *mockConfigLoader) Get(key string) (string, bool) {
+	value, exists := m.data[key]
+	return value, exists
+}
+
+func (m *mockConfigLoader) GetBool(key string) (bool, bool) {
+	if value, exists := m.data[key]; exists {
+		return value == "true", true
+	}
+	return false, false
+}
+
+func (m *mockConfigLoader) GetInt(key string) (int, bool) {
+	return 0, false
+}
+
+func (m *mockConfigLoader) GetIntWithDefault(key string, defaultValue int) int {
+	return defaultValue
+}
+
+func (m *mockConfigLoader) GetDuration(key string) (string, bool) {
+	return "", false
+}
+
+func (m *mockConfigLoader) GetDurationWithDefault(key string, defaultValue string) string {
+	return defaultValue
+}
+
+func (m *mockConfigLoader) HasPrefix(prefix string) map[string]string {
+	return make(map[string]string)
+}
+
+func (m *mockConfigLoader) GetWithDefault(key, defaultValue string) string {
+	if value, exists := m.data[key]; exists {
+		return value
+	}
+	return defaultValue
+}
+
+func (m *mockConfigLoader) GetBoolWithDefault(key string, defaultValue bool) bool {
+	if value, exists := m.data[key]; exists {
+		return value == "true"
+	}
+	return defaultValue
+}
+
+func TestProvider_Type(t *testing.T) {
+	provider := NewProvider(newMockCache(), &mockLockManager{}, &mockLogger{}, &mockMetrics{})
+
+	if provider.Type() != auth.ProviderTypeAPIKey {
+		t.Errorf("Expected provider type %v, got %v", auth.ProviderTypeAPIKey, provider.Type())
+	}
+}
+
+func TestProvider_LoadConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		config      map[string]string
+		expectError bool
+	}{
+		{
+			name: "valid config with keys",
+			config: map[string]string{
+				"api_key.keys":        "test_key_12345678:user1:test@example.com:Test User",
+				"api_key.header_name": "X-API-Key",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid config with multiple keys",
+			config: map[string]string{
+				"api_key.keys": "key1_12345678901234:user1:test1@example.com:User One,key2_12345678901234:user2:test2@example.com:User Two",
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid config - short key",
+			config: map[string]string{
+				"api_key.keys": "short:user1",
+			},
+			expectError: true,
+		},
+		{
+			name: "invalid config - no keys",
+			config: map[string]string{
+				"api_key.header_name": "X-API-Key",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewProvider(newMockCache(), &mockLockManager{}, &mockLogger{}, &mockMetrics{})
+			loader := newMockConfigLoader(tt.config)
+
+			err := provider.LoadConfig(loader)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestProvider_Validate(t *testing.T) {
+	// Setup provider with test configuration
+	provider := NewProvider(newMockCache(), &mockLockManager{}, &mockLogger{}, &mockMetrics{})
+	config := map[string]string{
+		"api_key.keys":        "test_api_key_123456:user123:test@example.com:Test User",
+		"api_key.header_name": "X-API-Key",
+	}
+	loader := newMockConfigLoader(config)
+
+	err := provider.LoadConfig(loader)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		authCtx     *auth.AuthContext
+		expectError bool
+		expectedSub string
+	}{
+		{
+			name: "valid API key in header",
+			authCtx: &auth.AuthContext{
+				Headers: map[string]string{
+					"X-API-Key": "test_api_key_123456",
+				},
+			},
+			expectError: false,
+			expectedSub: "user123",
+		},
+		{
+			name: "valid API key in Authorization header",
+			authCtx: &auth.AuthContext{
+				Headers: map[string]string{
+					"Authorization": "Bearer test_api_key_123456",
+				},
+			},
+			expectError: false,
+			expectedSub: "user123",
+		},
+		{
+			name: "invalid API key",
+			authCtx: &auth.AuthContext{
+				Headers: map[string]string{
+					"X-API-Key": "invalid_key",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing API key",
+			authCtx: &auth.AuthContext{
+				Headers: map[string]string{},
+			},
+			expectError: true,
+		},
+		{
+			name: "empty API key",
+			authCtx: &auth.AuthContext{
+				Headers: map[string]string{
+					"X-API-Key": "",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			claims, err := provider.Validate(ctx, tt.authCtx)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !tt.expectError && claims != nil {
+				if claims.Subject != tt.expectedSub {
+					t.Errorf("Expected subject %s, got %s", tt.expectedSub, claims.Subject)
+				}
+				if claims.Provider != auth.ProviderTypeAPIKey {
+					t.Errorf("Expected provider %v, got %v", auth.ProviderTypeAPIKey, claims.Provider)
+				}
+				if claims.Email != "test@example.com" {
+					t.Errorf("Expected email test@example.com, got %s", claims.Email)
+				}
+				if claims.Name != "Test User" {
+					t.Errorf("Expected name 'Test User', got %s", claims.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestProvider_ValidateWithCache(t *testing.T) {
+	cache := newMockCache()
+	provider := NewProvider(cache, &mockLockManager{}, &mockLogger{}, &mockMetrics{})
+
+	config := map[string]string{
+		"api_key.keys": "cached_key_123456789:cached_user:cached@example.com:Cached User",
+	}
+	loader := newMockConfigLoader(config)
+
+	err := provider.LoadConfig(loader)
+	if err != nil {
+		t.Fatalf("Failed to load config: %v", err)
+	}
+
+	authCtx := &auth.AuthContext{
+		Headers: map[string]string{
+			"X-API-Key": "cached_key_123456789",
+		},
+	}
+
+	ctx := context.Background()
+
+	// First call - should miss cache and validate
+	claims1, err := provider.Validate(ctx, authCtx)
+	if err != nil {
+		t.Fatalf("First validation failed: %v", err)
+	}
+
+	// Second call - should hit cache
+	claims2, err := provider.Validate(ctx, authCtx)
+	if err != nil {
+		t.Fatalf("Second validation failed: %v", err)
+	}
+
+	// Claims should be identical
+	if claims1.Subject != claims2.Subject {
+		t.Error("Cached claims differ from original")
+	}
+}
+
+func TestProvider_Health(t *testing.T) {
+	tests := []struct {
+		name        string
+		configured  bool
+		expectError bool
+	}{
+		{
+			name:        "healthy configured provider",
+			configured:  true,
+			expectError: false,
+		},
+		{
+			name:        "unhealthy unconfigured provider",
+			configured:  false,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := NewProvider(newMockCache(), &mockLockManager{}, &mockLogger{}, &mockMetrics{})
+
+			if tt.configured {
+				config := map[string]string{
+					"api_key.keys": "health_test_key_123456:health_user:health@example.com:Health User",
+				}
+				loader := newMockConfigLoader(config)
+				err := provider.LoadConfig(loader)
+				if err != nil {
+					t.Fatalf("Failed to load config: %v", err)
+				}
+			}
+
+			ctx := context.Background()
+			err := provider.Health(ctx)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected health check to fail but it passed")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected health check error: %v", err)
+			}
+		})
+	}
+}
+
+func TestParseAPIKeysFromString(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectError bool
+		expectedLen int
+	}{
+		{
+			name:        "single key",
+			input:       "test_key_1234567890123456:user1:email1@example.com:User One",
+			expectError: false,
+			expectedLen: 1,
+		},
+		{
+			name:        "multiple keys",
+			input:       "key1_1234567890123456:user1:email1@example.com:User One,key2_1234567890123456:user2:email2@example.com:User Two",
+			expectError: false,
+			expectedLen: 2,
+		},
+		{
+			name:        "key without optional fields",
+			input:       "simple_key_1234567890:simple_user",
+			expectError: false,
+			expectedLen: 1,
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			expectError: false,
+			expectedLen: 0,
+		},
+		{
+			name:        "invalid format",
+			input:       "invalid",
+			expectError: true,
+		},
+		{
+			name:        "empty key",
+			input:       ":user1",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, err := ParseAPIKeysFromString(tt.input)
+
+			if tt.expectError && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !tt.expectError && len(keys) != tt.expectedLen {
+				t.Errorf("Expected %d keys, got %d", tt.expectedLen, len(keys))
+			}
+		})
+	}
+}

--- a/internal/providers/firebase/provider.go
+++ b/internal/providers/firebase/provider.go
@@ -165,11 +165,11 @@ func (p *Provider) Validate(ctx context.Context, authCtx *auth.AuthContext) (*au
 
 	// Generate cache key for this token
 	cacheKey := p.generateCacheKey(tokenString)
-	
+
 	// Use lock to prevent concurrent validation of the same token
 	p.lockManager.Lock(cacheKey)
 	defer p.lockManager.Unlock(cacheKey)
-	
+
 	// Check cache first
 	if cachedClaims := p.getCachedClaims(ctx, cacheKey); cachedClaims != nil {
 		p.logger.Debug("cache hit for token validation", "subject", cachedClaims.Subject)

--- a/internal/providers/ip_whitelist/provider.go
+++ b/internal/providers/ip_whitelist/provider.go
@@ -85,7 +85,7 @@ func (p *Provider) LoadConfig(loader auth.ConfigLoader) error {
 	return nil
 }
 
-// Validate validates IP whitelist authentication from AuthContext  
+// Validate validates IP whitelist authentication from AuthContext
 func (p *Provider) Validate(ctx context.Context, authCtx *auth.AuthContext) (*auth.UserClaims, error) {
 	start := time.Now()
 	defer func() {


### PR DESCRIPTION
- Implement composable API key provider with header/Bearer token support
- Add comprehensive configuration with string and JSON formats
- Include caching, health checks, and provider statistics
- Support custom claims and admin flags
- Add extensive unit tests for provider and configuration
- Update main registration and configuration examples